### PR TITLE
Fehlerkorrekturen

### DIFF
--- a/Systemtheorie.tex
+++ b/Systemtheorie.tex
@@ -195,13 +195,13 @@
     Kurve, die Gebiete mit verschiedenem Langzeitverhalten trennt.
     \subsection{Lösung der Zustandsgleichungen}
     \subsubsection{Homogener Fall}
-    Transformation autonom (konst. Erregung) $\ra$ homogener Fall mit: $x' = x - x_\infty$.\\ \\
-    $\lambda_1 \neq \lambda_2$: $c_1\e^{\lambda_1t}\v q_1 + c_2\e^{\lambda_2t}\v q_2$\\
-    $\lambda_1 = \lambda_2 = \lambda$: $\e^{\lambda t}(\ma 1 + (\ma A -\lambda \ma 1)t) [q_1 q_2]^T$\\
+    Transformation autonom (konst. Erregung) $\ra$ homogener Fall mit: $\ \v x' = \v x - \v x_\infty$.\\ \\
+    $\lambda_1 \neq \lambda_2$: $\v x(t) = \ c_1\e^{\lambda_1t}\v q_1 + c_2\e^{\lambda_2t}\v q_2$\\
+    $\lambda_1 = \lambda_2 = \lambda$: $\v x(t) = e^{\lambda t}(\ma 1 + (\ma A -\lambda \ma 1)t) [q_1 q_2]^T$\\
     komplexe Eigenwerte: $c_1 \e^{\alpha t}(\cos{(\beta t)}\v q_{\text{reell}} - \sin{(\beta t)}\v q_{\text{imag}} + c_2\e^{\alpha t}(\sin{(\beta t)}\v q_{\text{reell}} - \cos{(\beta t)}\v q_{\text{imag}})$\\
     \subsubsection{Transformation auf Normalform}
     Gegeben: $\dot{x} = \ma A x$\\
-    Normalgleichung: $\dot{\xi} = \ma{A}\xi$\\
+    Normalgleichung: $\dot{\xi} = \Lambda{}\xi$\\
     Eigenwerte $\lambda_1, \lambda_2$ und Eigenvektoren $\v q_1, \v q_2$ berechnen\\
     $\ma Q =  \mat{\v q_1 & \v q_2 }$\\
     $\Lambda = \ma Q^{-1}\ma A\ma Q = \mat{\lambda_1 & 0 \\ 0 & \lambda_2 }, \xi = \ma Q^{-1} x$\\
@@ -214,10 +214,10 @@
     Rücktransformation: $\v x(t) = \ma Q'\xi '(t) = \v q_1'\xi_1'(t) + \v q_2'\xi_2'(t)$\\
     \subsubsection{Transformation auf reellwertige Normalform}
     Gegeben: $\lambda_{1/2} = \alpha \pm \beta j, \v q_r, \v q_i$\\
-    $A_\text{reell} =  \mat{\alpha & - \beta \\ \beta & \alpha}$\\
+    $\Lambda_\text{reell} =  \mat{\alpha & - \beta \\ \beta & \alpha}$\\
     $Q_\text{reell} = \mat{ q_r & - q_i}$\\
     $x_\text{reell} = \ma Q_\text{reell}^{-1} \e^{\Delta t}\ma Q_\text{reell}$\\
-    $\dot{x}_\text{reell} (t) = A_\text{reell}x_\text{reell}(t)$\\
+    $\dot{\xi}_\text{reell} (t) = \Lambda_\text{reell}\xi_\text{reell}(t)$\\
     \subsection{Zeitverlauf der Zustandsvariablen}
     Eigenwerte: $\lambda_i = \alpha + j\beta$ mit Dämpfung $\alpha$ und Schwingung $\beta$\\
     \textbf{Stabilität:} stabil, falls $\alpha < 0$, sonst instabil\\


### PR DESCRIPTION
Weitere Fehlerkorrekturen

Ich habe jetzt nur Sachen korrigiert, bei denen ich aufgrund des Skripts recht sicher bin, dass das so passt.
Bitte hier nochmal prüfen, ob die vorletzte Zeile auf dem Screenshot passt. Ich konnte das so nirgendswo im Skript finden (Das ist nichts was ich geändert hab, das war schon so auf der Formelsammlung).
![PDFAnnotator_2020-06-20_18-01-28](https://user-images.githubusercontent.com/25205082/85206135-59299480-b30f-11ea-9fc6-bc5e8acdfb72.png)


Ich frag mich allerdings, warum ich beim Kompilieren immer 50 Tausend Fehler und Warnungen bekomme, auch wenn die FS erstellt wird.

```
option also
(scrartcl)              is not recommended.

(C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/koma-script\typearea.sty

Package typearea Warning: DIV for 6.0pt and used papersize
(typearea)                not defined!
(typearea)                Using DIV=calc.

DIV calculation for typearea with good linewidth.

Package typearea Warning: Very low DIV value!
(typearea)                DIV values less than 6 result in textwidth/-height
(typearea)                smaller than total marginwidth/-height.
(typearea)                You should e.g. increase DIV, increase fontsize or
(typearea)                change papersize.

)) ("W:\Program Files\MiKTeX 2.9\tex/latex/base\inputenc.sty") ("W:\Program Files\MiKTeX 2.9\tex/generic/babel\babel.sty" ("W:\Program Files\MiKTeX 2.9\tex/generic/babel\babel.def" ("W:\Program Files\MiKTeX 2.9\tex/generic/babel\txtbabel.def"))
*************************************
* Local config file bblopts.cfg used
*
("W:\Program Files\MiKTeX 2.9\tex/latex/arabi\bblopts.cfg") ("W:\Program Files\MiKTeX 2.9\tex/latex/babel-english\english.ldf") (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/babel-german\german.ldf (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/babel-german\germanb.ldf))) ("W:\Program Files\MiKTeX 2.9\tex/latex/tools\multicol.sty") ("W:\Program Files\MiKTeX 2.9\tex/latex/graphics\graphicx.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/graphics\graphics.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/graphics\trig.sty") ("W:\Program Files\MiKTeX 2.9\tex/latex/graphics-cfg\graphics.cfg") ("W:\Program Files\MiKTeX 2.9\tex/latex/graphics-def\pdftex.def"))) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/pbox\pbox.sty ("W:\Program Files\MiKTeX 2.9\tex/latex/tools\calc.sty") ("W:\Program Files\MiKTeX 2.9\tex/latex/base\ifthen.sty")) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/koma-script\scrtime.sty)

Class scrartcl Warning: Usage of package `parskip' together
(scrartcl)              with a KOMA-Script class is not recommended.
(scrartcl)              I'd suggest to use option
(scrartcl)              `parskip' with one of it's several values.
(scrartcl)              Nevertheless, using requested
(scrartcl)              package `parskip' on input line 22.

(C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/parskip\parskip.sty (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/kvoptions\kvoptions.sty (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/ltxcmds\ltxcmds.sty) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/kvsetkeys\kvsetkeys.sty)) ("W:\Program Files\MiKTeX 2.9\tex/latex/etoolbox\etoolbox.sty")
Couldn't patch \@startsection
) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/titlesec\titlesec.sty

Package titlesec Warning: Non standard sectioning command \section
(titlesec)                detected. Using default spacing and no format.


Package titlesec Warning: Non standard sectioning command \subsection
(titlesec)                detected. Using default spacing and no format.


Package titlesec Warning: Non standard sectioning command \subsubsection
(titlesec)                detected. Using default spacing and no format.


Package titlesec Warning: Non standard sectioning command \paragraph
(titlesec)                detected. Using default spacing and no format.


Package titlesec Warning: Non standard sectioning command \subparagraph
(titlesec)                detected. Using default spacing and no format.

) ("W:\Program Files\MiKTeX 2.9\tex/latex/xcolor\xcolor.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/graphics-cfg\color.cfg")) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/geometry\geometry.sty ("W:\Program Files\MiKTeX 2.9\tex/generic/iftex\ifvtex.sty" ("W:\Program Files\MiKTeX 2.9\tex/generic/iftex\iftex.sty")) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/geometry\geometry.cfg))

Class scrartcl Warning: Usage of package `fancyhdr' together
(scrartcl)              with a KOMA-Script class is not recommended.
(scrartcl)              I'd suggest to use 
(scrartcl)              package `scrlayer' or `scrlayer-scrpage', because
(scrartcl)              they support KOMA-Script classes.
(scrartcl)              With `fancyhdr' several features of class `scrartcl'
(scrartcl)              like options `headsepline', `footsepline' or command
(scrartcl)              `\MakeMarkcase' and the commands `\setkomafont' and
(scrartcl)              `\addtokomafont' for the page style elements need
(scrartcl)              explicite user intervention to work.
(scrartcl)              Nevertheless, using requested
(scrartcl)              package `fancyhdr' on input line 30.

(C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/fancyhdr\fancyhdr.sty) (v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\scientific.sty (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/xifthen\xifthen.sty (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/ifmtarg\ifmtarg.sty)) ("W:\Program Files\MiKTeX 2.9\tex/latex/amsmath\amsmath.sty"
For additional information on amsmath, use the `?' option.
("W:\Program Files\MiKTeX 2.9\tex/latex/amsmath\amstext.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/amsmath\amsgen.sty")) ("W:\Program Files\MiKTeX 2.9\tex/latex/amsmath\amsbsy.sty") ("W:\Program Files\MiKTeX 2.9\tex/latex/amsmath\amsopn.sty")) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/accents\accents.sty) ("W:\Program Files\MiKTeX 2.9\tex/latex/amsfonts\amssymb.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/amsfonts\amsfonts.sty")) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/esint\esint.sty) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/mhchem\mhchem.sty ("W:\Program Files\MiKTeX 2.9\tex/latex/l3kernel\expl3.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/l3backend\l3backend-pdfmode.def")) ("W:\Program Files\MiKTeX 2.9\tex/latex/l3packages/l3keys2e\l3keys2e.sty") (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/chemgreek\chemgreek.sty ("W:\Program Files\MiKTeX 2.9\tex/latex/l3packages/xparse\xparse.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/l3packages/xparse\xparse-generic.tex")))) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/siunitx\siunitx.sty ("W:\Program Files\MiKTeX 2.9\tex/latex/tools\array.sty") (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/translator\translator.sty)) ("W:\Program Files\MiKTeX 2.9\tex/latex/amsfonts\umsa.fd") ("W:\Program Files\MiKTeX 2.9\tex/latex/amsfonts\umsb.fd") (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/esint\uesint.fd)) (v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\latex4ei.sty)) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/circuitikz\circuitikz.sty ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/frontendlayer\tikz.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/basiclayer\pgf.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/utilities\pgfrcs.sty" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfutil-common.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfutil-common-lists.tex")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfutil-latex.def" ("W:\Program Files\MiKTeX 2.9\tex/latex/ms\everyshi.sty")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfrcs.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf\pgf.revision.tex"))) ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/basiclayer\pgfcore.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/systemlayer\pgfsys.sty" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/systemlayer\pgfsys.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfkeys.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfkeysfiltered.code.tex")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/systemlayer\pgf.cfg") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/systemlayer\pgfsys-pdftex.def" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/systemlayer\pgfsys-common-pdf.def"))) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/systemlayer\pgfsyssoftpath.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/systemlayer\pgfsysprotocol.code.tex")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcore.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmath.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathcalc.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathutil.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathparser.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.basic.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.trigonometric.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.random.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.comparison.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.base.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.round.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.misc.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfunctions.integerarithmetics.code.tex"))) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmathfloat.code.tex")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfint.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorepoints.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorepathconstruct.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorepathusage.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorescopes.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoregraphicstate.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoretransformations.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorequick.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoreobjects.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorepathprocessing.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorearrows.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoreshade.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoreimage.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoreexternal.code.tex")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorelayers.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcoretransparency.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorepatterns.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/basiclayer\pgfcorerdf.code.tex"))) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/modules\pgfmoduleshapes.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/modules\pgfmoduleplot.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/compatibility\pgfcomp-version-0-65.sty") ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/compatibility\pgfcomp-version-1-18.sty")) ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/utilities\pgffor.sty" ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/utilities\pgfkeys.sty" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgfkeys.code.tex")) ("W:\Program Files\MiKTeX 2.9\tex/latex/pgf/math\pgfmath.sty" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmath.code.tex")) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/utilities\pgffor.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/math\pgfmath.code.tex"))) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/frontendlayer/tikz\tikz.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/libraries\pgflibraryplothandlers.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/modules\pgfmodulematrix.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/frontendlayer/tikz/libraries\tikzlibrarytopaths.code.tex"))) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/frontendlayer/tikz/libraries\tikzlibrarycalc.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/libraries\pgflibraryarrows.meta.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/frontendlayer/tikz/libraries\tikzlibrarybending.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/modules\pgfmodulebending.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/modules\pgfmodulenonlineartransformations.code.tex") ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/libraries\pgflibrarycurvilinear.code.tex"))) ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/frontendlayer/tikz/libraries\tikzlibraryfpu.code.tex" ("W:\Program Files\MiKTeX 2.9\tex/generic/pgf/libraries\pgflibraryfpu.code.tex")) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcirc.defines.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircutils.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircshapes.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircmonopoles.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircbipoles.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcirctripoles.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircquadpoles.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircmultipoles.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcirclabel.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircvoltage.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcirccurrent.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircflow.tex) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/generic/circuitikz\pgfcircpath.tex)

Package circuitikz Warning: You did not specify one of the voltage directions:
(circuitikz)                  oldvoltagedirection, nooldvoltagedirection, 
(circuitikz)                  RPvoltages or EFvoltages 
(circuitikz)                Default directions may have changed, 
(circuitikz)                please check the manual.

) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/multirow\multirow.sty) (v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\latexnew.sty (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/mathtools\mathtools.sty (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/mathtools\mhsetup.sty)))

LaTeX Warning: Unused global option(s):
    [landscape].

(v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\Systemtheorie.aux) ("W:\Program Files\MiKTeX 2.9\tex/context/base/mkii\supp-pdf.mkii"
[Loading MPS to PDF converter (version 2006.09.02).]
) ("W:\Program Files\MiKTeX 2.9\tex/latex/epstopdf-pkg\epstopdf-base.sty")
*geometry* driver: auto-detecting
*geometry* detected driver: pdftex
(C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/translator\translator-basic-dictionary-English.dict) (C:\Users\florian2833z.DIETRICH\AppData\Roaming\MiKTeX\2.9\tex/latex/siunitx\siunitx-abbreviations.cfg) ABD: EveryShipout initializing macros

LaTeX Font Warning: Font shape `OT1/cmss/bx/n' in size <12.44403> not available
(Font)              size <12> substituted on input line 17.


LaTeX Font Warning: Font shape `OT1/cmr/m/n' in size <3.59999> not available
(Font)              size <5> substituted on input line 21.


LaTeX Font Warning: Font shape `OML/cmm/m/it' in size <3.59999> not available
(Font)              size <5> substituted on input line 21.


LaTeX Font Warning: Font shape `OMS/cmsy/m/n' in size <3.59999> not available
(Font)              size <5> substituted on input line 21.


LaTeX Font Warning: Font shape `OT1/cmss/m/n' in size <3.59999> not available
(Font)              size <5> substituted on input line 21.


LaTeX Font Warning: Font shape `OT1/cmtt/m/n' in size <3.59999> not available
(Font)              size <5> substituted on input line 21.


LaTeX Font Warning: Font shape `OT1/cmss/bx/it' undefined
(Font)              using `OT1/cmss/bx/n' instead on input line 24.


Underfull \hbox (badness 10000) in paragraph at lines 23--28


Underfull \hbox (badness 10000) in paragraph at lines 23--28

v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:28: Missing number, treated as zero.
<to be read again> 
                   }
l.28 ...on{Allgemeine Zusammenhänge $u,i,q,\Phi$}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:28: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.28 ...on{Allgemeine Zusammenhänge $u,i,q,\Phi$}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:40: Missing number, treated as zero.
<to be read again> 
                   }
l.40     \subsubsection{Arten von Bauelementen}
                                               
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:40: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.40     \subsubsection{Arten von Bauelementen}
                                               

Overfull \hbox (0.68456pt too wide) in paragraph at lines 41--48
[] 
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:48: Missing number, treated as zero.
<to be read again> 
                   }
l.48 ...ubsubsection{Zusammenhang der Bauelemente}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:48: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.48 ...ubsubsection{Zusammenhang der Bauelemente}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:52: Missing number, treated as zero.
<to be read again> 
                   }
l.52 ...ubsubsection{Eigenschaften von Reaktanzen}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:52: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.52 ...ubsubsection{Eigenschaften von Reaktanzen}
                                                  

Underfull \hbox (badness 10000) in paragraph at lines 53--69

v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:69: Missing number, treated as zero.
<to be read again> 
                   }
l.69 ...subsubsection{Verschaltung von Reaktanzen}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:69: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.69 ...subsubsection{Verschaltung von Reaktanzen}
                                                  

Underfull \hbox (badness 10000) in paragraph at lines 70--72


Underfull \hbox (badness 10000) in paragraph at lines 74--76

v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:77: Missing number, treated as zero.
<to be read again> 
                   }
l.77     \subsubsection{Dualität}
                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:77: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.77     \subsubsection{Dualität}
                                  

Overfull \hbox (3.81046pt too wide) in paragraph at lines 126--127
[]|  [][][] 
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:135: Missing number, treated as zero.
<to be read again> 
                   }
l.135     \subsubsection{Sprungantwort}
                                       
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:135: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.135     \subsubsection{Sprungantwort}
                                       
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:138: Missing number, treated as zero.
<to be read again> 
                   }
l.138     \subsubsection{Impulsantwort}
                                       
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:138: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.138     \subsubsection{Impulsantwort}
                                       

Overfull \hbox (21.66574pt too wide) in paragraph at lines 139--142
\OT1/cmss/m/n/6 Einheitsimpuls: $\OML/cmm/m/it/6 \OT1/cmr/m/n/6 (\OML/cmm/m/it/6 t\OT1/cmr/m/n/6 ) = []$ 
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:167: Missing number, treated as zero.
<to be read again> 
                   }
l.167 ...bsubsection{Zeichnen des Phasenportraits}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:167: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.167 ...bsubsection{Zeichnen des Phasenportraits}
                                                  

Underfull \hbox (badness 10000) in paragraph at lines 168--191

[1{C:/Users/florian2833z.DIETRICH/AppData/Local/MiKTeX/2.9/pdftex/config/pdftex.map} <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/Logo.pdf> <./img/Resistivitat.pdf> <./img/Kapazivitat.pdf

pdfTeX warning: pdflatex (file ./img/Kapazivitat.pdf): PDF inclusion: multiple pdfs with page group included in a single page
> <./img/Induktivitat.pdf

pdfTeX warning: pdflatex (file ./img/Induktivitat.pdf): PDF inclusion: multiple pdfs with page group included in a single page
> <./img/Memristivitat.pdf

pdfTeX warning: pdflatex (file ./img/Memristivitat.pdf): PDF inclusion: multiple pdfs with page group included in a single page
> <./img/reactance_overview.pdf

pdfTeX warning: pdflatex (file ./img/reactance_overview.pdf): PDF inclusion: multiple pdfs with page group included in a single page
> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/helmholtz-thevenin.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/mayer-norton.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/graph-stabil.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/graph-instabil.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/phase-strudel.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/phase-wirbel.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/phase-knoten.png>]
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:191: Missing number, treated as zero.
<to be read again> 
                   }
l.191     \subsubsection{Isokline}
                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:191: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.191     \subsubsection{Isokline}
                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:194: Missing number, treated as zero.
<to be read again> 
                   }
l.194     \subsubsection{Separatrix}
                                    
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:194: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.194     \subsubsection{Separatrix}
                                    
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:197: Missing number, treated as zero.
<to be read again> 
                   }
l.197     \subsubsection{Homogener Fall}
                                        
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:197: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.197     \subsubsection{Homogener Fall}
                                        

Underfull \hbox (badness 10000) in paragraph at lines 198--202


Underfull \hbox (badness 10000) in paragraph at lines 198--202
\OT1/cmss/m/n/6 komplexe Ei-gen-wer-te: $\OML/cmm/m/it/6 c[]\OT1/cmr/m/n/6 e[]([] [][][] \OMS/cmsy/m/n/6 238     \subsubsection{Sprungantwort}
                                       

Underfull \hbox (badness 10000) in paragraph at lines 240--242

v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:242: Missing number, treated as zero.
<to be read again> 
                   }
l.242     \subsubsection{Impulsantwort}
                                       
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:242: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.242     \subsubsection{Impulsantwort}
                                       
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:247: Missing number, treated as zero.
<to be read again> 
                   }
l.247     \subsubsection{Steady-State-Antwort}
                                              
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:247: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.247     \subsubsection{Steady-State-Antwort}
                                              
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:250: Missing number, treated as zero.
<to be read again> 
                   }
l.250     \subsubsection{Transientenantwort}
                                            
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:250: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.250     \subsubsection{Transientenantwort}
                                            

Underfull \hbox (badness 10000) in paragraph at lines 262--267


Overfull \hbox (1.41669pt too wide) in paragraph at lines 269--277
[]$ $[]$ 

Overfull \hbox (1.41669pt too wide) in paragraph at lines 269--277
[] [] 

Underfull \hbox (badness 10000) in paragraph at lines 313--313


Overfull \hbox (3.81046pt too wide) in paragraph at lines 286--326
|  [][][]

Overfull \hbox (3.81046pt too wide) in paragraph at lines 286--326
|  [][][] 

Underfull \hbox (badness 10000) in paragraph at lines 328--332

v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:332: Missing number, treated as zero.
<to be read again> 
                   }
l.332     \subsubsection{Rechenregeln}
                                      
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:332: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.332     \subsubsection{Rechenregeln}
                                      
("W:\Program Files\MiKTeX 2.9\tex/latex/base\ts1cmss.fd")
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:338: Missing number, treated as zero.
<to be read again> 
                   }
l.338 ...ection{Wichtige Laplace-Transformationen}
                                                  
v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.tex:338: Illegal unit of measure (pt inserted).
<to be read again> 
                   }
l.338 ...ection{Wichtige Laplace-Transformationen}
                                                  

Overfull \hbox (7.3105pt too wide) in paragraph at lines 347--364
\OML/cmm/m/it/6 \OT1/cmr/m/n/6 (\OML/cmm/m/it/6 !\OT1/cmr/m/n/6 ) = \U/msa/m/n/6 \\OML/cmm/m/it/6 H\OT1/cmr/m/n/6 (\OML/cmm/m/it/6 j!\OT1/cmr/m/n/6 ) = []$ 

Underfull \hbox (badness 10000) in paragraph at lines 347--364


Underfull \hbox (badness 10000) in paragraph at lines 367--369


Underfull \hbox (badness 10000) in paragraph at lines 369--374


Underfull \hbox (badness 10000) in paragraph at lines 387--387
[]\OT1/cmss/m/n/6 Hier: Wi-der-stand-sorts-kur-ve

Overfull \hbox (1.41667pt too wide) in paragraph at lines 385--388
$[]$ $[]$ 
[2 <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/phase-sattel.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/van-der-pol.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/fast-harmonischer-oszillator.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/relaxationsoszillator.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/relaxationsoszillator-schaltung.png>]
Underfull \hbox (badness 10000) in paragraph at lines 404--405
[]\OT1/cmtt/m/n/6 C<Name> <Knoten1> <Knoten2> <Wert>\OT1/cmss/m/n/6 : Kon-den-sa-tor zwi-schen

Underfull \hbox (badness 10000) in paragraph at lines 407--408
[]\OT1/cmtt/m/n/6 I<Name> <Knoten1> <Knoten2> <Wert>\OT1/cmss/m/n/6 : Strom-quel-le zwi-schen

LaTeX Font Warning: Font shape `OMS/cmtt/m/n' undefined
(Font)              using `OMS/cmsy/m/n' instead
(Font)              for symbol `textbraceleft' on input line 411.


Underfull \hbox (badness 10000) in paragraph at lines 411--412
[]\OT1/cmtt/m/n/6 .step param <Param> <Start> <End> <Step>\OT1/cmss/m/n/6 : Al-le Pa-ra-me-ter

Underfull \hbox (badness 10000) in paragraph at lines 412--413
[]\OT1/cmtt/m/n/6 .step param <Param> list <Wert1> <Wert2> ...\OT1/cmss/m/n/6 : Si-mu-la-ti-on
[3 <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/ortskurve-r.png> <v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/img/filtertypen.png>] (v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\Systemtheorie.aux)

LaTeX Font Warning: Size substitutions with differences
(Font)              up to 1.40001pt have occurred.


LaTeX Font Warning: Some font shapes were not available, defaults substituted.


LaTeX Warning: There were undefined references.


LaTeX Warning: Label(s) may have changed. Rerun to get cross-references right.

 )
(see the transcript file for additional information) <C:\Users\florian2833z.DIETRICH\AppData\Local\MiKTeX\2.9\fonts/pk/ljfour/jknappen/ec/dpi600\tcss0600.pk> <C:\Users\florian2833z.DIETRICH\AppData\Local\MiKTeX\2.9\fonts/pk/ljfour/public/esint/dpi360\esint10.pk><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmbx7.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cmextra/cmex7.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmmi5.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmmi6.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmmi7.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmr5.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmr6.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmr7.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmss8.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmssbx10.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmssi8.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmsy5.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmsy6.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/cm/cmtt8.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/symbols/msam7.pfb><W:/Program Files/MiKTeX 2.9/fonts/type1/public/amsfonts/symbols/msbm7.pfb>
Output written on v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\Systemtheorie.pdf (3 pages, 680529 bytes).
SyncTeX written on v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\Systemtheorie.synctex.gz.
Transcript written on v:/Users\florian2833z\Downloads\tmp\Systemtheorie-fix-1\Systemtheorie.log.
pdflatex: major issue: User/administrator updates are out-of-sync.
Latexmk: References changed.
Latexmk: Log file says output to 'Systemtheorie.pdf'
Latexmk: List of undefined refs and citations:
  Reference `sec:Sprung- und Impulsantwort' on page 2 undefined on input line 235
Latexmk: Summary of warnings from last run of (pdf)latex:
  Latex failed to resolve 1 reference(s)
Collected error summary (may duplicate other messages):
  pdflatex: Command for 'pdflatex' gave return code 1
      Refer to 'v:/Users/florian2833z/Downloads/tmp/Systemtheorie-fix-1/Systemtheorie.log' for details
=== TeX engine is 'pdfTeX'
Latexmk: Errors, so I did not complete making targets
Latexmk: Use the -f option to force complete processing,
 unless error was exceeding maximum runs, or warnings treated as errors.
latexmk: major issue: User/administrator updates are out-of-sync.

```